### PR TITLE
simplify logging for pytest

### DIFF
--- a/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -10,8 +10,7 @@ import unittest
 import {{ cookiecutter.project_slug }}
 
 
-_logger: logging.Logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 
 
 class Test{{ cookiecutter.project_slug|title }}(unittest.TestCase):


### PR DESCRIPTION
We don't need our own instance of the logger here.